### PR TITLE
MKPL-1657 Provider version upload from GitHub Action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2026081901 ###
+
+* Enable publishing new plugin versions to Moodle Marketplace.
+
 ### 2021070201 ###
 
 * Use `--data-urlencode` for curl arguments to fix troubles with special characters in

--- a/README.md
+++ b/README.md
@@ -1,56 +1,20 @@
-# Releasing Moodle plugins in the Plugins directory automatically from GitHub Actions
-
-> [!WARNING]
-> **Publishing plugin versions through the API is temporarily unavailable**
-> 
-> Following the move from the Plugins Directory to Moodle Marketplace, this GitHub Action can no longer be used to publish new plugin versions through the API. Restoring automated uploads is the team's highest development priority after launch.
-> 
-> See [Launch limitations and upcoming functionality](https://moodle.atlassian.net/wiki/external/OTE3YmUxNTI3YzYzNGJmMzgwZWVjNTEzYTk2ZGE2ZDk#Upload-plugin-versions-through-the-API) for more information.
+# Releasing Moodle plugin versions in Moodle Marketplace from GitHub Actions
 
 ## Usage
 
-1. Copy the template file [moodle-release.yml](https://github.com/moodlehq/moodle-plugin-release/blob/main/moodle-release.yml)
-   into the `.github/workflows/moodle-release.yml` location within your plugin
-   repository.
-2. Edit the file and set the `PLUGIN` environment variable to the full component name
-   (aka frankenstyle) of your plugin. Example:
+1. Copy the template file [moodle-release.yml](https://github.com/moodlehq/moodle-plugin-release/blob/main/moodle-release.yml) into the `.github/workflows/moodle-release.yml` location within your plugin repository.
 
-   ```
-    env:
-      PLUGIN: mod_subcourse
-   ```
+2. Log in to the Moodle Marketplace. Navigate to Account Settings > Security (https://marketplace.moodle.com/account/security) and create a new API token. Copy the token immediately, as it is only displayed once.
 
-   There should be no need to edit any other line as long as you are happy with the
-   default behaviour of the workflow.  Please refer to the GitHub Actions
-   documentation for details.
+3. Go to your plugin repository on GitHub. Navigate to "Settings" > "Secrets and Variables" > "Actions". Click "New repository secret", name it `MOODLE_MARKETPLACE_TOKEN`, and paste your API access token as the value.
 
-3. Log in to the Moodle Plugins directory at <https://moodle.org/plugins/>. Locate the
-   Navigation block > Plugins > API access. Use that page to generate your personal
-   token for the `plugins_maintenance` service.
-
-4. Go back to your plugin repository at Github. Locate your plugin's Settings >
-   Secrets section. Use the 'New repository secret' button to define a new repository
-   secret to hold your access token. Use name `MOODLE_ORG_TOKEN` and set the value to
-   the one you generated in previous step.
-
-5. That's it! Now when you tag the repository with a tag that matches the configured
-   condition, the tagged version will be released in the plugins directory.
+4. That's it! Now when you tag the repository with a tag that matches the configured condition (starts with v (e.g., v1.4.0)), the tagged version will be released in Moodle Marketplace.
 
 
 ## Tips
 
-* Use settings `$plugin->requires`, `$plugin->supported` and
-  `$plugin->incompatible` in your plugin's
-  [version.php](https://docs.moodle.org/dev/version.php). They are used to
-  automatically populate the list of supported Moodle versions. By default, all Moodle
-  versions starting from the one described by `$plugin->requires` will be marked as
-  supported.
-* Keep the `CHANGES.md` file in the root of your repository. It will be automatically
-  imported as release notes for the new version. Please see [Moodle dev
-  docs](https://docs.moodle.org/dev/Plugin_files#CHANGES) for all supported names and
-  formats.
-* If your release tags do not start with `v` character (such as `v9.0.1`) and you want
-  to trigger the workflow for any tag, change the condition in the YAML file as:
+* Provide release notes when creating a GitHub Release. The workflow will automatically use your GitHub Release description.
+* If your release tags do not start with `v` character (such as `v9.0.1`) and you want to trigger the workflow for any tag, change the condition in the YAML file as:
 
   ```
   on:
@@ -58,6 +22,7 @@
       tags:
         - '*'
   ```
+* Marketplace API documentation is located at [moodledev.io](https://moodledev.io/general/community/plugincontribution/moodlemarketplaceapi)
 
 
 ## License

--- a/moodle-release.yml
+++ b/moodle-release.yml
@@ -1,20 +1,20 @@
 #
 # Whenever a new tag starting with "v" is pushed, add the tagged version
-# to the Moodle Plugins directory at https://moodle.org/plugins
+# to Moodle Marketplace at https://marketplace.moodle.com/
 #
-# revision: 2021070201
+# revision: 2026082001
 #
-name: Releasing in the Plugins directory
+name: Release Plugin version to Moodle Marketplace
 
 on:
   push:
     tags:
-      - v*
+      - 'v*'
 
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to be released'
+        description: 'Tag to be released (e.g. v1.4.0)'
         required: true
 
 defaults:
@@ -22,45 +22,95 @@ defaults:
     shell: bash
 
 jobs:
-  release-at-moodle-org:
+  release-to-marketplace:
     runs-on: ubuntu-latest
+
     env:
-      PLUGIN: <put the frankenstyle component name of your plugin here>
-      CURL: curl -s
-      ENDPOINT: https://moodle.org/webservice/rest/server.php
-      TOKEN: ${{ secrets.MOODLE_ORG_TOKEN }}
-      FUNCTION: local_plugins_add_version
+      BASE_URL: 'https://marketplace.moodle.com/api'
+      TOKEN: ${{ secrets.MOODLE_MARKETPLACE_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Call the service function
-        id: add-version
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Resolve Tag Name
+        id: resolve-tag
         run: |
-          if [[ ! -z "${{ github.event.inputs.tag }}" ]]; then
-            TAGNAME="${{ github.event.inputs.tag }}"
-          elif [[ $GITHUB_REF = refs/tags/* ]]; then
+          TAGNAME="${{ github.event.inputs.tag }}"
+          if [[ -z "${TAGNAME}" && $GITHUB_REF == refs/tags/* ]]; then
             TAGNAME="${GITHUB_REF##*/}"
           fi
+
           if [[ -z "${TAGNAME}" ]]; then
-            echo "No tag name has been provided!"
+            echo "::error::No tag name provided!"
             exit 1
           fi
-          ZIPURL="https://api.github.com/repos/${{ github.repository }}/zipball/${TAGNAME}"
-          RESPONSE=$(${CURL} ${ENDPOINT} --data-urlencode "wstoken=${TOKEN}" \
-                                         --data-urlencode "wsfunction=${FUNCTION}" \
-                                         --data-urlencode "moodlewsrestformat=json" \
-                                         --data-urlencode "frankenstyle=${PLUGIN}" \
-                                         --data-urlencode "zipurl=${ZIPURL}" \
-                                         --data-urlencode "vcssystem=git" \
-                                         --data-urlencode "vcsrepositoryurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
-                                         --data-urlencode "vcstag=${TAGNAME}" \
-                                         --data-urlencode "changelogurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commits/${TAGNAME}" \
-                                         --data-urlencode "altdownloadurl=${ZIPURL}")
-          echo "response=${RESPONSE}" >> $GITHUB_OUTPUT
 
-      - name: Evaluate the response
-        id: evaluate-response
-        env:
-          RESPONSE: ${{ steps.add-version.outputs.response }}
+          echo "tag=${TAGNAME}" >> $GITHUB_OUTPUT
+
+      - name: Build Zip Package
+        id: package
         run: |
-          jq <<< ${RESPONSE}
-          jq --exit-status ".id" <<< ${RESPONSE} > /dev/null
+          COMPONENT=$(php -r '$c = file_get_contents("version.php"); preg_match("/component\s*=\s*[\x27\"]([a-z0-9_]+)[\x27\"]/", $c, $m); echo $m[1] ?? "";')
+
+          if [[ -z "$COMPONENT" ]]; then
+            echo "::error::Could not read \$plugin->component from version.php"
+            exit 1
+          fi
+
+          DIRNAME="${COMPONENT#*_}"
+          ZIP_FILE="${DIRNAME}.zip"
+
+          git archive --format=zip --prefix="${DIRNAME}/" -o "$ZIP_FILE" HEAD
+
+          echo "component=${COMPONENT}" >> $GITHUB_OUTPUT
+          echo "zip_file=${ZIP_FILE}" >> $GITHUB_OUTPUT
+
+      - name: Extract Release Notes
+        id: release_notes
+        env:
+          TAGNAME: ${{ steps.resolve-tag.outputs.tag }}
+        run: |
+          NOTES=$(gh release view "$TAGNAME" --json body -q '.body' 2>/dev/null || true)
+
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Submit Version to Marketplace API
+        env:
+          TAGNAME: ${{ steps.resolve-tag.outputs.tag }}
+          COMPONENT: ${{ steps.package.outputs.component }}
+          ZIP_FILE: ${{ steps.package.outputs.zip_file }}
+          NOTES: ${{ steps.release_notes.outputs.notes }}
+        run: |
+          ENDPOINT="${BASE_URL}/plugins/${COMPONENT}/versions"
+
+          echo "Submitting $ZIP_FILE for component $COMPONENT to $ENDPOINT..."
+
+          HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -F "file=@${ZIP_FILE}" \
+            -F "releaseNotes=${NOTES}" \
+            -F "vcsTag=${TAGNAME}" \
+            "${ENDPOINT}")
+
+          echo "Response HTTP Status: ${HTTP_STATUS}"
+          echo "Response Body:"
+          jq . response.json 2>/dev/null || cat response.json
+
+          if [[ "${HTTP_STATUS}" -ne 201 ]]; then
+            echo "::error::API returned failure status: ${HTTP_STATUS}"
+
+            if jq -e '.violations' response.json >/dev/null 2>&1; then
+              echo "Validation Violations:"
+              jq '.violations' response.json
+            fi
+
+            exit 1
+          fi
+
+          VERSION_ID=$(jq -r '.id' response.json)
+          echo "Successfully created version ID: ${VERSION_ID}"


### PR DESCRIPTION
As of the issue MKPL-1657, this allows the user to publish a new plugin version in Moodle Marketplace by just creating a release with a tag starting with `v`.