### PR TITLE
Introduce reusable workflow.

### DIFF
--- a/.github/workflows/moodle-release.yml
+++ b/.github/workflows/moodle-release.yml
@@ -1,20 +1,23 @@
 #
-# Whenever a new tag starting with "v" is pushed, add the tagged version
-# to Moodle Marketplace at https://marketplace.moodle.com/
+# Reusable workflow: submit a tagged Moodle plugin version to Moodle Marketplace
+# at https://marketplace.moodle.com/
 #
-# revision: 2026082001
+# Call this workflow from your plugin repository, see README.md for details.
+#
+# revision: 2026082501
 #
 name: Release Plugin version to Moodle Marketplace
 
 on:
-  push:
-    tags:
-      - 'v*'
-
-  workflow_dispatch:
+  workflow_call:
     inputs:
       tag:
         description: 'Tag to be released (e.g. v1.4.0)'
+        required: false
+        type: string
+    secrets:
+      MOODLE_MARKETPLACE_TOKEN:
+        description: 'API token generated at https://marketplace.moodle.com/account/security'
         required: true
 
 defaults:
@@ -37,7 +40,7 @@ jobs:
       - name: Resolve Tag Name
         id: resolve-tag
         run: |
-          TAGNAME="${{ github.event.inputs.tag }}"
+          TAGNAME="${{ inputs.tag }}"
           if [[ -z "${TAGNAME}" && $GITHUB_REF == refs/tags/* ]]; then
             TAGNAME="${GITHUB_REF##*/}"
           fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 2026082501 ###
+
+* Converted the template into a reusable workflow (`workflow_call`), located at
+  `.github/workflows/moodle-release.yml`. Plugin repositories now add a small caller
+  workflow instead of copying the whole file — see README.md for the updated usage.
+
 ### 2026081901 ###
 
 * Enable publishing new plugin versions to Moodle Marketplace.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 ## Usage
 
-1. Copy the template file [moodle-release.yml](https://github.com/moodlehq/moodle-plugin-release/blob/main/moodle-release.yml) into the `.github/workflows/moodle-release.yml` location within your plugin repository.
+This is a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows). Instead of copying the whole file, add a small caller workflow to your plugin repository.
+
+1. Create `.github/workflows/moodle-release.yml` in your plugin repository with the following content:
+
+   ```yaml
+   name: Release Plugin version to Moodle Marketplace
+
+   on:
+     push:
+       tags:
+         - 'v*'
+
+   jobs:
+     release-to-marketplace:
+       uses: moodlehq/moodle-plugin-release/.github/workflows/moodle-release.yml@main
+       with:
+         tag: ${{ github.event.inputs.tag }}
+       secrets:
+         MOODLE_MARKETPLACE_TOKEN: ${{ secrets.MOODLE_MARKETPLACE_TOKEN }}
+   ```
 
 2. Log in to the Moodle Marketplace. Navigate to "Account Settings" > "Security" (https://marketplace.moodle.com/account/security) and create a new API token. Copy the token immediately, as it is only displayed once.
 
@@ -14,7 +33,7 @@
 ## Tips
 
 * Provide release notes when creating a GitHub Release. The workflow will automatically use your GitHub Release description.
-* If your release tags do not start with `v` character (such as `v9.0.1`) and you want to trigger the workflow for any tag, change the condition in the YAML file as:
+* If your release tags do not start with `v` character (such as `v9.0.1`) and you want to trigger the workflow for any tag, change the condition in your caller workflow as:
 
   ```
   on:


### PR DESCRIPTION
@PhMemmel suggested to create reusable workflow, which indeed would simplify setup. It allows including release call as part of different workflow file (e.g. generate notes and release). This also allows us to manage changes without people need to update whole script if we change/fix something, although we need to make sure any change we merge would not break existing configurations.

Use example (testing PR): https://github.com/kabalin/moodle-media_jwplayer/blob/master/.github/workflows/release.yaml
Test run: https://github.com/kabalin/moodle-media_jwplayer/actions/runs/32901652672/job/97976650829#logs

Fixes #12